### PR TITLE
Migrate app from sre-provisioning to DK

### DIFF
--- a/.vtex/applications/kubernetes/search-tests/templates/stable.yaml
+++ b/.vtex/applications/kubernetes/search-tests/templates/stable.yaml
@@ -1,0 +1,19 @@
+base:
+  environment: stable
+  imageRepository: 053131491888.dkr.ecr.us-east-1.amazonaws.com
+  repoName: search-tests
+apps:
+- dockerfile: Dockerfile
+  imageRepoName: vtex/search-tests
+  kind: cronjob
+  name: search-tests
+  resources:
+    limits:
+      cpu: 800m
+      memory: 1500Mi
+    requests:
+      cpu: 400m
+      memory: 1000Mi
+  schedule: '*/6 * * * *'
+  secretsManager:
+    enabled: true

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,17 +1,34 @@
-- acronym: search-tests
+- name: dk-search-tests
+  description: Deployment of search-tests application using DK IaC and DK CICD
   build:
+    provider: dkcicd
     pipelines:
-    - name: drone-builder-v1
+    - name: application-build-v1
       parameters:
-        awsAccountId: "053131491888"
-        awsRegion: us-east-1
-        environment: stable
-      runtime:
-        architecture: amd64
+        acronym: search-tests
+        applicationName: search-tests
+        applicationType: k8s
+        baseBranch: setup/dk-kubernetes
+        chartName: sre-provisioning
+        dockerfilePath: Dockerfile
+        environmentType: stable
+        imageRepo: vtex/search-tests
+        imageTag: '{{ ref_name }}'
+        rollout: "true"
       when:
       - event: push
-        regex: main
+        source: tag
+        regex: ^((?!beta).)*$
+      runtime:
+        architecture: amd64
+    - name: application-deploy-v2
+      parameters:
+        acronym: search-tests
+        baseBranch: setup/dk-kubernetes
+        projectName: sre-apps
+      when:
+      - event: push
         source: branch
-    provider: dkcicd
-  description: Deploy with drone-builder
-  name: search-tests
+        regex: setup/dk-kubernetes
+      runtime:
+        architecture: amd64


### PR DESCRIPTION
This PR migrates the applications running in sre-provisioning to the new pipeline process.

The templates were created using the kubernetes files inside this repository. The tag event will trigger the build pipeline and automatically open a Pull Request with the new version, that needs to be approved and merged.

The pipelines are defined to only work in this branch, that means the PR will be created to be merged in this branch instead of main. In order to actually use it, you should do this steps before merge to main:
- Go to all pipelines and remove the parameter: `baseBranch: setup/dk-kubernetes`
- Go to all `application-deploy-v2` pipelines and change the `regex: setup/dk-kubernetes` to the default branch of your repository, e.g `regex: main` 
